### PR TITLE
MAGNETO_ROOT is not always available

### DIFF
--- a/app/code/community/Payfort/Pay/Model/Observer.php
+++ b/app/code/community/Payfort/Pay/Model/Observer.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once(MAGENTO_ROOT . '/lib/payfortFort/init.php');
+require_once( Mage::getBaseDir('lib') . '/payfortFort/init.php');
 
 class Payfort_Pay_Model_Observer extends Mage_CatalogInventory_Model_Observer
 {

--- a/app/code/community/Payfort/Pay/Model/Payment/Cc.php
+++ b/app/code/community/Payfort/Pay/Model/Payment/Cc.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once(MAGENTO_ROOT . '/lib/payfortFort/init.php');
+require_once(Mage::getBaseDir('lib') . '/payfortFort/init.php');
 
 class Payfort_Pay_Model_Payment_Cc extends Mage_Payment_Model_Method_Abstract
 {

--- a/app/code/community/Payfort/Pay/Model/Payment/Naps.php
+++ b/app/code/community/Payfort/Pay/Model/Payment/Naps.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once(MAGENTO_ROOT . '/lib/payfortFort/init.php');
+require_once(Mage::getBaseDir('lib') . '/payfortFort/init.php');
 
 class Payfort_Pay_Model_Payment_Naps extends Mage_Payment_Model_Method_Abstract
 {

--- a/app/code/community/Payfort/Pay/Model/Payment/Sadad.php
+++ b/app/code/community/Payfort/Pay/Model/Payment/Sadad.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once(MAGENTO_ROOT . '/lib/payfortFort/init.php');
+require_once(Mage::getBaseDir('lib') . '/payfortFort/init.php');
 
 class Payfort_Pay_Model_Payment_Sadad extends Mage_Payment_Model_Method_Abstract
 {


### PR DESCRIPTION
Creating order programmatically  from the API does not load the MAGENTO_ROOT variable