### PR TITLE
Fix signature mismatch when purchasing with specific amounts due to floating point limitations

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ This extension is customizable as you can configure it to meet your needs.
 
 ## Changelog
 
+`v1.2.5`
+- Fix signature mismatch on some specific amounts when purchasing.
+
 `v1.2.4`
 
 - Fix some bugs

--- a/lib/payfortFort/classes/Helper.php
+++ b/lib/payfortFort/classes/Helper.php
@@ -83,7 +83,7 @@ class Payfort_Fort_Helper
             $new_amount = round($amount, $decimal_points);
         }
         $new_amount = $new_amount * (pow(10, $decimal_points));
-        return $new_amount;
+        return "$new_amount";
     }
 
     /**

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package>
     <name>FORT_Payment_Gateway</name>
-    <version>1.2.4</version>
+    <version>1.2.5</version>
     <stability>stable</stability>
     <license>MIT</license>
     <channel>community</channel>


### PR DESCRIPTION
Merchants on Magento and PHP 7 encounter signature mismatch issues on specific amounts such as $0.14 or $136.2. This pull request fixes this issue. 